### PR TITLE
Orders module

### DIFF
--- a/db/models/Order.ts
+++ b/db/models/Order.ts
@@ -26,6 +26,7 @@ interface IOrderMethods { }
   
 interface OrderModel extends Model<Required<IOrder>, {}, IOrderMethods> {
     getAllOrders():  Promise<Array<HydratedDocument<Required<IOrder>, IOrderMethods>>>;
+    getOrder(orderId: string):  Promise<HydratedDocument<Required<IOrder>, IOrderMethods>>;
 }
 
 // Order schema based on Order interface
@@ -44,15 +45,33 @@ const orderSchema = new Schema<Required<IOrder>, OrderModel, IOrderMethods>({
 });
 
 /**
- * Gets all existing Orders
+ * Gets all existing orders
  * @returns Orders document array
  */
 orderSchema.static('getAllOrders', async function getAllOrders ():  Promise<Array<HydratedDocument<IOrder, IOrderMethods>>>{
-    const Orders = await Order.find();
+    const Orders = await Order.find({}, { _id : 0 });
     
     return Orders;
 });
 
+/**
+ * Gets an existing order
+ * @returns Order document
+ * @throws message
+ */
+orderSchema.static('getOrder', async function getOrder (orderId: string):  Promise<HydratedDocument<Required<IOrder>, IOrderMethods>> {
+    try{
+        const order = await Order.findOne({ '_id': orderId }, {'_id': 0 })
+                                    .populate('route', { _id : 0 }).populate('truck');
+        if(order !== null)
+            return order;
+
+        throw { message : 'The order does not exist.' };
+    } catch (err) {
+        // Invalid oid
+        throw { message : 'The order does not exist.' };
+    }
+});
 
 // Order model based on Order schema
 const Order = model<Required<IOrder>, OrderModel> ('Order' , orderSchema);

--- a/db/models/Order.ts
+++ b/db/models/Order.ts
@@ -8,14 +8,14 @@ enum OrderType {
 
 enum Status {
     Created,
-    Accepted,
+    Scheduled,
     OnProgress,
     Completed
 };
 
 // Order interface
 interface IOrder {
-    type: string;
+    type : string;
     description: string;
     route : Types.ObjectId;
     status : string;
@@ -24,23 +24,30 @@ interface IOrder {
 
 interface IOrderMethods {
     deleteOrder(): Promise<boolean>;
+    updateOrder(type: string | undefined, description: string | undefined,
+                routeId: Types.ObjectId | undefined, status: string | undefined,
+                truckId: Types.ObjectId | undefined): Promise<boolean>;
+    nextStatus(): Promise<boolean>;
 }
   
 interface OrderModel extends Model<Required<IOrder>, {}, IOrderMethods> {
     getAllOrders():  Promise<Array<HydratedDocument<Required<IOrder>, IOrderMethods>>>;
     getOrder(orderId: string):  Promise<HydratedDocument<Required<IOrder>, IOrderMethods>>;
+    getExtendedOrder(orderId: string):  Promise<HydratedDocument<Required<IOrder>, IOrderMethods>>;
 }
 
 // Order schema based on Order interface
 const orderSchema = new Schema<Required<IOrder>, OrderModel, IOrderMethods>({
     type: {
         type: String,
+        default: OrderType[OrderType.Normal],
         enum: Object.values(OrderType)
     },
     description: String,
     route : { type: 'ObjectID', ref: 'Route' },
     status : {
         type: String,
+        default: Status[Status.Created],
         enum: Object.values(Status)
     },
     truck : { type: 'ObjectID', ref: 'Truck' }
@@ -63,7 +70,26 @@ orderSchema.static('getAllOrders', async function getAllOrders ():  Promise<Arra
  */
 orderSchema.static('getOrder', async function getOrder (orderId: string):  Promise<HydratedDocument<Required<IOrder>, IOrderMethods>> {
     try{
-        const order = await Order.findOne({ '_id': orderId })
+        const order = await Order.findOne({ '_id': orderId });
+        if(order !== null)
+            return order;
+
+        throw { message : 'The order does not exist.' };
+    } catch (err) {
+        // Invalid oid
+        throw { message : 'The order does not exist.' };
+    }
+});
+
+/**
+ * Gets an existing order and populates it with the route and truck references.
+ * Omits order Id on order instance.
+ * @returns Order document
+ * @throws message
+ */
+orderSchema.static('getExtendedOrder', async function getExtendedOrder (orderId: string):  Promise<HydratedDocument<Required<IOrder>, IOrderMethods>> {
+    try{
+        const order = await Order.findOne({ '_id': orderId }, { _id : 0 })
                                     .populate('route', { _id : 0 }).populate('truck');
         if(order !== null)
             return order;
@@ -72,6 +98,54 @@ orderSchema.static('getOrder', async function getOrder (orderId: string):  Promi
     } catch (err) {
         // Invalid oid
         throw { message : 'The order does not exist.' };
+    }
+});
+
+/**
+ * Updates the current instance document 
+ * @returns boolean true when success
+ * @throws message
+ */
+orderSchema.method('updateOrder', async function updateOrder (type: string | undefined,
+                                description: string | undefined, routeId: Types.ObjectId | undefined,
+                                status: string | undefined, truckId: Types.ObjectId | undefined):  Promise<boolean> {
+    try{
+        if(this.status == Status[Status.OnProgress]) {
+            return false;
+        }
+
+        const update = await Order.updateOne({ _id : this._id }, {
+            type: type,
+            description: description,
+            route: routeId,
+            status: status,
+            truck: truckId
+        });
+        
+        if(update.acknowledged) return true;
+
+        throw { message : 'Error on updating order' };
+    } catch(e) {
+        throw { message : 'Error on updating order' };
+    }
+});
+
+/**
+ * Updates the status of the current instance
+ * @returns boolean true when success
+ * @throws message
+ */
+orderSchema.method('nextStatus', async function nextStatus ():  Promise<boolean> {
+    try{
+        if(this.status != Status[Status.Completed]) {
+            const update = await Order.updateOne({ _id : this._id }, {
+                status: Status[Status[this.status] + 1]
+            });
+            return update.acknowledged;
+        }
+        return false;
+    } catch(e) {
+        throw { message : 'Error on deleting order' };
     }
 });
 

--- a/db/models/Order.ts
+++ b/db/models/Order.ts
@@ -1,0 +1,62 @@
+import { Schema, model, Model, HydratedDocument, Types } from 'mongoose';
+
+enum orderType {
+    Normal,
+    Urgent,
+    Fragile
+};
+
+enum Status {
+    Created,
+    Accepted,
+    OnProgress,
+    Completed
+};
+
+// Order interface
+interface IOrder {
+    type: number;
+    description: string;
+    route : Types.ObjectId;
+    status : number;
+    truck : Types.ObjectId;
+}
+
+interface IOrderMethods { }
+  
+interface OrderModel extends Model<Required<IOrder>, {}, IOrderMethods> {
+    getAllOrders():  Promise<Array<HydratedDocument<Required<IOrder>, IOrderMethods>>>;
+}
+
+// Order schema based on Order interface
+const orderSchema = new Schema<Required<IOrder>, OrderModel, IOrderMethods>({
+    type: {
+        type: Number,
+        default: orderType.Normal,
+        enum: Object.values(orderType)
+    },
+    description: String,
+    route : { type: 'ObjectID', ref: 'Route' },
+    status : {
+        type: Number,
+        default: Status.Created,
+        enum: Object.values(Status)
+    },
+    truck : { type: 'ObjectID', ref: 'Truck' },
+});
+
+/**
+ * Gets all existing Orders
+ * @returns Orders document array
+ */
+orderSchema.static('getAllOrders', async function getAllOrders ():  Promise<Array<HydratedDocument<IOrder, IOrderMethods>>>{
+    const Orders = await Order.find();
+    
+    return Orders;
+});
+
+
+// Order model based on Order schema
+const Order = model<Required<IOrder>, OrderModel> ('Order' , orderSchema);
+
+export { Order }

--- a/db/models/Order.ts
+++ b/db/models/Order.ts
@@ -1,6 +1,6 @@
 import { Schema, model, Model, HydratedDocument, Types } from 'mongoose';
 
-enum orderType {
+enum OrderType {
     Normal,
     Urgent,
     Fragile
@@ -15,10 +15,10 @@ enum Status {
 
 // Order interface
 interface IOrder {
-    type: number;
+    type: string;
     description: string;
     route : Types.ObjectId;
-    status : number;
+    status : string;
     truck : Types.ObjectId;
 }
 
@@ -31,18 +31,16 @@ interface OrderModel extends Model<Required<IOrder>, {}, IOrderMethods> {
 // Order schema based on Order interface
 const orderSchema = new Schema<Required<IOrder>, OrderModel, IOrderMethods>({
     type: {
-        type: Number,
-        default: orderType.Normal,
-        enum: Object.values(orderType)
+        type: String,
+        enum: Object.values(OrderType)
     },
     description: String,
     route : { type: 'ObjectID', ref: 'Route' },
     status : {
-        type: Number,
-        default: Status.Created,
+        type: String,
         enum: Object.values(Status)
     },
-    truck : { type: 'ObjectID', ref: 'Truck' },
+    truck : { type: 'ObjectID', ref: 'Truck' }
 });
 
 /**
@@ -59,4 +57,4 @@ orderSchema.static('getAllOrders', async function getAllOrders ():  Promise<Arra
 // Order model based on Order schema
 const Order = model<Required<IOrder>, OrderModel> ('Order' , orderSchema);
 
-export { Order }
+export { Order, OrderType, Status}

--- a/db/models/Order.ts
+++ b/db/models/Order.ts
@@ -22,7 +22,9 @@ interface IOrder {
     truck : Types.ObjectId;
 }
 
-interface IOrderMethods { }
+interface IOrderMethods {
+    deleteOrder(): Promise<boolean>;
+}
   
 interface OrderModel extends Model<Required<IOrder>, {}, IOrderMethods> {
     getAllOrders():  Promise<Array<HydratedDocument<Required<IOrder>, IOrderMethods>>>;
@@ -61,7 +63,7 @@ orderSchema.static('getAllOrders', async function getAllOrders ():  Promise<Arra
  */
 orderSchema.static('getOrder', async function getOrder (orderId: string):  Promise<HydratedDocument<Required<IOrder>, IOrderMethods>> {
     try{
-        const order = await Order.findOne({ '_id': orderId }, {'_id': 0 })
+        const order = await Order.findOne({ '_id': orderId })
                                     .populate('route', { _id : 0 }).populate('truck');
         if(order !== null)
             return order;
@@ -72,6 +74,24 @@ orderSchema.static('getOrder', async function getOrder (orderId: string):  Promi
         throw { message : 'The order does not exist.' };
     }
 });
+
+/**
+ * Deletes the current instance document 
+ * @returns boolean true when success
+ * @throws message
+ */
+orderSchema.method('deleteOrder', async function deleteOrder ():  Promise<boolean> {
+    try{
+        if(this.status == Status[Status.OnProgress]) {
+            return false;
+        }
+        await this.deleteOne();
+        return true;
+    } catch(e) {
+        throw { message : 'Error on deleting order' };
+    }
+});
+
 
 // Order model based on Order schema
 const Order = model<Required<IOrder>, OrderModel> ('Order' , orderSchema);

--- a/db/models/Point.ts
+++ b/db/models/Point.ts
@@ -34,7 +34,7 @@ const pointSchema = new Schema<Required<IPoint>, PointModel, IPointMethods>({
  * @returns Points document array
  */
 pointSchema.static('getAllPoints', async function getAllPoints ():  Promise<Array<HydratedDocument<IPoint, IPointMethods>>>{
-    const points = await Point.find();
+    const points = await Point.find({}, {'_id': 0 });
     
     return points;
 });
@@ -45,7 +45,7 @@ pointSchema.static('getAllPoints', async function getAllPoints ():  Promise<Arra
  * @throws message
  */
 pointSchema.static('getPoint', async function getPoint (name : string):  Promise<HydratedDocument<Required<IPoint>, IPointMethods>> {
-    const point = await Point.findOne({ 'location.name' : name });
+    const point = await Point.findOne({ 'location.name' : name }, {'_id': 0 });
     if(point !== null)
         return point;
 

--- a/db/models/Route.ts
+++ b/db/models/Route.ts
@@ -47,7 +47,7 @@ const routeSchema = new Schema<Required<IRoute>, RouteModel, IRouteMethods>({
  * @returns Routes document array
  */
 routeSchema.static('getAllRoutes', async function getAllRoutes ():  Promise<Array<HydratedDocument<IRoute, IRouteMethods>>>{
-    const routes = await Route.find();
+    const routes = await Route.find({}, {'_id': 0 });
     
     return routes;
 });
@@ -62,12 +62,12 @@ routeSchema.static('routeExists', async function routeExists (namePointA: string
 });
 
 /**
- * Gets an existing route, if it exists
+ * Gets an existing route
  * @returns Route document
  * @throws message
  */
 routeSchema.static('getRoute', async function getRoute (namePointA: string, namePointB: string):  Promise<HydratedDocument<Required<IRoute>, IRouteMethods>> {
-    const route = await Route.findOne({ "pointA.name": namePointA, "pointB.name": namePointB });
+    const route = await Route.findOne({ "pointA.name": namePointA, "pointB.name": namePointB }, {'_id': 0 });
     if(route !== null)
         return route;
 

--- a/db/models/Route.ts
+++ b/db/models/Route.ts
@@ -1,4 +1,4 @@
-import { Schema, model, Model, HydratedDocument, Types } from 'mongoose';
+import { Schema, model, Model, HydratedDocument } from 'mongoose';
 
 // Route interface
 interface IRoute {

--- a/db/models/Route.ts
+++ b/db/models/Route.ts
@@ -1,4 +1,4 @@
-import { Schema, model, Model, HydratedDocument } from 'mongoose';
+import { Schema, model, Model, HydratedDocument, Types } from 'mongoose';
 
 // Route interface
 interface IRoute {
@@ -25,6 +25,7 @@ interface RouteModel extends Model<Required<IRoute>, {}, IRouteMethods> {
     getAllRoutes():  Promise<Array<HydratedDocument<Required<IRoute>, IRouteMethods>>>;
     routeExists(pointA: string, pointB: string):  Promise<boolean>;
     getRoute(pointA: string, pointB: string):  Promise<HydratedDocument<Required<IRoute>, IRouteMethods>>;
+    getRouteById(routeId: Types.ObjectId):  Promise<HydratedDocument<Required<IRoute>, IRouteMethods>>;
 }
 
 // Route schema based on Route interface
@@ -67,7 +68,20 @@ routeSchema.static('routeExists', async function routeExists (namePointA: string
  * @throws message
  */
 routeSchema.static('getRoute', async function getRoute (namePointA: string, namePointB: string):  Promise<HydratedDocument<Required<IRoute>, IRouteMethods>> {
-    const route = await Route.findOne({ "pointA.name": namePointA, "pointB.name": namePointB }, {'_id': 0 });
+    const route = await Route.findOne({ "pointA.name": namePointA, "pointB.name": namePointB });
+    if(route !== null)
+        return route;
+
+    throw { message : 'The route does not exist.' };
+});
+
+/**
+ * Gets an existing route by Id
+ * @returns Route document
+ * @throws message
+ */
+routeSchema.static('getRouteById', async function getRouteById (routeId: Types.ObjectId):  Promise<HydratedDocument<Required<IRoute>, IRouteMethods>> {
+    const route = await Route.findOne({ "_id": routeId });
     if(route !== null)
         return route;
 

--- a/db/models/Truck.ts
+++ b/db/models/Truck.ts
@@ -67,6 +67,7 @@ truckSchema.static('getTruck', async function getTruck (truckId: string):  Promi
 
         throw { message : 'Invalid truck.' };
     } catch(err) {
+        // Invalid oid
         throw { message : 'Invalid truck.' };
     }
 });

--- a/db/models/Truck.ts
+++ b/db/models/Truck.ts
@@ -14,6 +14,7 @@ interface ITruckMethods { }
   
 interface TruckModel extends Model<Required<ITruck>, {}, ITruckMethods> {
     getAllTrucks():  Promise<Array<HydratedDocument<ITruck, ITruckMethods>>>;
+    getTruck(truckId: string):  Promise<HydratedDocument<ITruck, ITruckMethods>>;
 }
 
 // Truck schema based on Truck interface
@@ -52,7 +53,23 @@ truckSchema.static('getAllTrucks', async function getAllTrucks ():  Promise<Arra
     const trucks = await Truck.find();
     
     return trucks;
-})
+});
+
+/**
+ * Gets all existing trucks
+ * @returns Trucks document array
+ */
+truckSchema.static('getTruck', async function getTruck (truckId: string):  Promise<HydratedDocument<ITruck, ITruckMethods>> {
+    try{
+        const truck = await Truck.findOne({_id: truckId});
+        if(truck !== null)
+            return truck;
+
+        throw { message : 'Invalid truck.' };
+    } catch(err) {
+        throw { message : 'Invalid truck.' };
+    }
+});
 
 // Truck model based on Truck schema
 const Truck = model<Required<ITruck>, TruckModel> ('Truck' , truckSchema);

--- a/dist/db/models/Order.js
+++ b/dist/db/models/Order.js
@@ -38,13 +38,33 @@ const orderSchema = new Schema({
     truck: { type: 'ObjectID', ref: 'Truck' }
 });
 /**
- * Gets all existing Orders
+ * Gets all existing orders
  * @returns Orders document array
  */
 orderSchema.static('getAllOrders', function getAllOrders() {
     return __awaiter(this, void 0, void 0, function* () {
-        const Orders = yield Order.find();
+        const Orders = yield Order.find({}, { _id: 0 });
         return Orders;
+    });
+});
+/**
+ * Gets an existing order
+ * @returns Order document
+ * @throws message
+ */
+orderSchema.static('getOrder', function getOrder(orderId) {
+    return __awaiter(this, void 0, void 0, function* () {
+        try {
+            const order = yield Order.findOne({ '_id': orderId }, { '_id': 0 })
+                .populate('route', { _id: 0 }).populate('truck');
+            if (order !== null)
+                return order;
+            throw { message: 'The order does not exist.' };
+        }
+        catch (err) {
+            // Invalid oid
+            throw { message: 'The order does not exist.' };
+        }
     });
 });
 // Order model based on Order schema

--- a/dist/db/models/Order.js
+++ b/dist/db/models/Order.js
@@ -55,7 +55,7 @@ orderSchema.static('getAllOrders', function getAllOrders() {
 orderSchema.static('getOrder', function getOrder(orderId) {
     return __awaiter(this, void 0, void 0, function* () {
         try {
-            const order = yield Order.findOne({ '_id': orderId }, { '_id': 0 })
+            const order = yield Order.findOne({ '_id': orderId })
                 .populate('route', { _id: 0 }).populate('truck');
             if (order !== null)
                 return order;
@@ -64,6 +64,25 @@ orderSchema.static('getOrder', function getOrder(orderId) {
         catch (err) {
             // Invalid oid
             throw { message: 'The order does not exist.' };
+        }
+    });
+});
+/**
+ * Deletes the current instance document
+ * @returns boolean true when success
+ * @throws message
+ */
+orderSchema.method('deleteOrder', function deleteOrder() {
+    return __awaiter(this, void 0, void 0, function* () {
+        try {
+            if (this.status == Status[Status.OnProgress]) {
+                return false;
+            }
+            yield this.deleteOne();
+            return true;
+        }
+        catch (e) {
+            throw { message: 'Error on deleting order' };
         }
     });
 });

--- a/dist/db/models/Order.js
+++ b/dist/db/models/Order.js
@@ -1,0 +1,54 @@
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+import { Schema, model } from 'mongoose';
+var orderType;
+(function (orderType) {
+    orderType[orderType["Normal"] = 0] = "Normal";
+    orderType[orderType["Urgent"] = 1] = "Urgent";
+    orderType[orderType["Fragile"] = 2] = "Fragile";
+})(orderType || (orderType = {}));
+;
+var Status;
+(function (Status) {
+    Status[Status["Created"] = 0] = "Created";
+    Status[Status["Accepted"] = 1] = "Accepted";
+    Status[Status["OnProgress"] = 2] = "OnProgress";
+    Status[Status["Completed"] = 3] = "Completed";
+})(Status || (Status = {}));
+;
+// Order schema based on Order interface
+const orderSchema = new Schema({
+    type: {
+        type: Number,
+        default: orderType.Normal,
+        enum: Object.values(orderType)
+    },
+    description: String,
+    route: { type: 'ObjectID', ref: 'Route' },
+    status: {
+        type: Number,
+        default: Status.Created,
+        enum: Object.values(Status)
+    },
+    truck: { type: 'ObjectID', ref: 'Truck' },
+});
+/**
+ * Gets all existing Orders
+ * @returns Orders document array
+ */
+orderSchema.static('getAllOrders', function getAllOrders() {
+    return __awaiter(this, void 0, void 0, function* () {
+        const Orders = yield Order.find();
+        return Orders;
+    });
+});
+// Order model based on Order schema
+const Order = model('Order', orderSchema);
+export { Order };

--- a/dist/db/models/Order.js
+++ b/dist/db/models/Order.js
@@ -8,12 +8,12 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 import { Schema, model } from 'mongoose';
-var orderType;
-(function (orderType) {
-    orderType[orderType["Normal"] = 0] = "Normal";
-    orderType[orderType["Urgent"] = 1] = "Urgent";
-    orderType[orderType["Fragile"] = 2] = "Fragile";
-})(orderType || (orderType = {}));
+var OrderType;
+(function (OrderType) {
+    OrderType[OrderType["Normal"] = 0] = "Normal";
+    OrderType[OrderType["Urgent"] = 1] = "Urgent";
+    OrderType[OrderType["Fragile"] = 2] = "Fragile";
+})(OrderType || (OrderType = {}));
 ;
 var Status;
 (function (Status) {
@@ -26,18 +26,16 @@ var Status;
 // Order schema based on Order interface
 const orderSchema = new Schema({
     type: {
-        type: Number,
-        default: orderType.Normal,
-        enum: Object.values(orderType)
+        type: String,
+        enum: Object.values(OrderType)
     },
     description: String,
     route: { type: 'ObjectID', ref: 'Route' },
     status: {
-        type: Number,
-        default: Status.Created,
+        type: String,
         enum: Object.values(Status)
     },
-    truck: { type: 'ObjectID', ref: 'Truck' },
+    truck: { type: 'ObjectID', ref: 'Truck' }
 });
 /**
  * Gets all existing Orders
@@ -51,4 +49,4 @@ orderSchema.static('getAllOrders', function getAllOrders() {
 });
 // Order model based on Order schema
 const Order = model('Order', orderSchema);
-export { Order };
+export { Order, OrderType, Status };

--- a/dist/db/models/Point.js
+++ b/dist/db/models/Point.js
@@ -27,7 +27,7 @@ const pointSchema = new Schema({
  */
 pointSchema.static('getAllPoints', function getAllPoints() {
     return __awaiter(this, void 0, void 0, function* () {
-        const points = yield Point.find();
+        const points = yield Point.find({}, { '_id': 0 });
         return points;
     });
 });
@@ -38,7 +38,7 @@ pointSchema.static('getAllPoints', function getAllPoints() {
  */
 pointSchema.static('getPoint', function getPoint(name) {
     return __awaiter(this, void 0, void 0, function* () {
-        const point = yield Point.findOne({ 'location.name': name });
+        const point = yield Point.findOne({ 'location.name': name }, { '_id': 0 });
         if (point !== null)
             return point;
         throw { message: 'Invalid point' };

--- a/dist/db/models/Route.js
+++ b/dist/db/models/Route.js
@@ -28,7 +28,7 @@ const routeSchema = new Schema({
  */
 routeSchema.static('getAllRoutes', function getAllRoutes() {
     return __awaiter(this, void 0, void 0, function* () {
-        const routes = yield Route.find();
+        const routes = yield Route.find({}, { '_id': 0 });
         return routes;
     });
 });
@@ -43,13 +43,13 @@ routeSchema.static('routeExists', function routeExists(namePointA, namePointB) {
     });
 });
 /**
- * Gets an existing route, if it exists
+ * Gets an existing route
  * @returns Route document
  * @throws message
  */
 routeSchema.static('getRoute', function getRoute(namePointA, namePointB) {
     return __awaiter(this, void 0, void 0, function* () {
-        const route = yield Route.findOne({ "pointA.name": namePointA, "pointB.name": namePointB });
+        const route = yield Route.findOne({ "pointA.name": namePointA, "pointB.name": namePointB }, { '_id': 0 });
         if (route !== null)
             return route;
         throw { message: 'The route does not exist.' };

--- a/dist/db/models/Route.js
+++ b/dist/db/models/Route.js
@@ -49,7 +49,20 @@ routeSchema.static('routeExists', function routeExists(namePointA, namePointB) {
  */
 routeSchema.static('getRoute', function getRoute(namePointA, namePointB) {
     return __awaiter(this, void 0, void 0, function* () {
-        const route = yield Route.findOne({ "pointA.name": namePointA, "pointB.name": namePointB }, { '_id': 0 });
+        const route = yield Route.findOne({ "pointA.name": namePointA, "pointB.name": namePointB });
+        if (route !== null)
+            return route;
+        throw { message: 'The route does not exist.' };
+    });
+});
+/**
+ * Gets an existing route by Id
+ * @returns Route document
+ * @throws message
+ */
+routeSchema.static('getRouteById', function getRouteById(routeId) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const route = yield Route.findOne({ "_id": routeId });
         if (route !== null)
             return route;
         throw { message: 'The route does not exist.' };

--- a/dist/db/models/Truck.js
+++ b/dist/db/models/Truck.js
@@ -45,6 +45,23 @@ truckSchema.static('getAllTrucks', function getAllTrucks() {
         return trucks;
     });
 });
+/**
+ * Gets all existing trucks
+ * @returns Trucks document array
+ */
+truckSchema.static('getTruck', function getTruck(truckId) {
+    return __awaiter(this, void 0, void 0, function* () {
+        try {
+            const truck = yield Truck.findOne({ _id: truckId });
+            if (truck !== null)
+                return truck;
+            throw { message: 'Invalid truck.' };
+        }
+        catch (err) {
+            throw { message: 'Invalid truck.' };
+        }
+    });
+});
 // Truck model based on Truck schema
 const Truck = model('Truck', truckSchema);
 export { Truck };

--- a/dist/db/models/Truck.js
+++ b/dist/db/models/Truck.js
@@ -58,6 +58,7 @@ truckSchema.static('getTruck', function getTruck(truckId) {
             throw { message: 'Invalid truck.' };
         }
         catch (err) {
+            // Invalid oid
             throw { message: 'Invalid truck.' };
         }
     });

--- a/dist/main.js
+++ b/dist/main.js
@@ -6,6 +6,7 @@ import { authRouter } from './src/routes/auth.js';
 import { pointsRouter } from './src/routes/points.js';
 import { trucksRouter } from './src/routes/trucks.js';
 import { routesRouter } from './src/routes/routes.js';
+import { ordersRouter } from './src/routes/orders.js';
 import { notFound, validRequest } from './src/middleware/validation.js';
 setDBConnection().catch(err => {
     console.log('Unable to connect to DB');
@@ -23,6 +24,7 @@ app.use(validRequest);
 app.use('/points', pointsRouter);
 app.use('/trucks', trucksRouter);
 app.use('/routes', routesRouter);
+app.use('/orders', ordersRouter);
 // Server validation
 app.use(notFound);
 // API

--- a/dist/src/controllers/orders.js
+++ b/dist/src/controllers/orders.js
@@ -66,7 +66,7 @@ function CreateOrder(req, res) {
     });
 }
 /**
- * Retrieves an existing Order
+ * Retrieves an existing order
  */
 function ReadOrder(req, res) {
     return __awaiter(this, void 0, void 0, function* () {
@@ -86,4 +86,31 @@ function ReadOrder(req, res) {
         }
     });
 }
-export { AllOrders, CreateOrder, ReadOrder };
+/**
+ * Deletes an existing order
+ */
+function DeleteOrder(req, res) {
+    return __awaiter(this, void 0, void 0, function* () {
+        try {
+            const result = validationResult(req);
+            if (!result.isEmpty()) { // Valid data for request
+                return res.status(400).send({ success: false, errors: result.array().map(function (err) {
+                        return err.msg; // Returns errors of data validation
+                    }) });
+            }
+            const data = matchedData(req);
+            // If both points are valid, look for Order
+            var order = yield Order.getOrder(data.orderId);
+            if (yield order.deleteOrder()) {
+                return res.status(200).send({ success: true, message: 'Order was successfully deleted' });
+            }
+            else {
+                return res.status(200).send({ success: false, message: 'The order is in progress. It cannot be deleted.' });
+            }
+        }
+        catch (error) {
+            return res.status(400).send({ success: false, message: error.message });
+        }
+    });
+}
+export { AllOrders, CreateOrder, ReadOrder, DeleteOrder };

--- a/dist/src/controllers/orders.js
+++ b/dist/src/controllers/orders.js
@@ -65,4 +65,25 @@ function CreateOrder(req, res) {
         }
     });
 }
-export { AllOrders, CreateOrder };
+/**
+ * Retrieves an existing Order
+ */
+function ReadOrder(req, res) {
+    return __awaiter(this, void 0, void 0, function* () {
+        try {
+            const result = validationResult(req);
+            if (!result.isEmpty()) { // Valid data for request
+                return res.status(400).send({ success: false, errors: result.array().map(function (err) {
+                        return err.msg; // Returns errors of data validation
+                    }) });
+            }
+            const data = matchedData(req);
+            var order = yield Order.getOrder(data.orderId);
+            return res.status(200).send({ success: true, order: order });
+        }
+        catch (error) {
+            return res.status(400).send({ success: false, message: error.message });
+        }
+    });
+}
+export { AllOrders, CreateOrder, ReadOrder };

--- a/dist/src/controllers/orders.js
+++ b/dist/src/controllers/orders.js
@@ -7,7 +7,11 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
-import { Order } from '../../db/models/Order.js';
+import { validationResult, matchedData } from 'express-validator';
+import { Order, OrderType, Status } from '../../db/models/Order.js';
+import { Route } from '../../db/models/Route.js';
+import { Truck } from '../../db/models/Truck.js';
+import { Point } from '../../db/models/Point.js';
 /**
  * Retrieves all orders available.
  */
@@ -22,4 +26,43 @@ function AllOrders(req, res) {
         }
     });
 }
-export { AllOrders };
+/**
+ * Creates a new valid order.
+ */
+function CreateOrder(req, res) {
+    return __awaiter(this, void 0, void 0, function* () {
+        try {
+            const result = validationResult(req);
+            if (!result.isEmpty()) { // Valid data for request
+                return res.status(400).send({ success: false, errors: result.array().map(function (err) {
+                        return err.msg; // Returns errors of data validation
+                    }) });
+            }
+            const data = matchedData(req);
+            if (data.route.pickup == data.route.dropoff) { // Departure and arrival must be different.
+                return res.status(400).send({ success: false, message: 'Invalid route payload' });
+            }
+            // First, verify that the starting and the ending Points are valid.
+            yield Point.getPoint(data.route.pickup);
+            yield Point.getPoint(data.route.dropoff);
+            // Verify valid route
+            const route = yield Route.getRoute(data.route.pickup, data.route.dropoff);
+            // Verify valid truck
+            const truck = yield Truck.getTruck(data.truck);
+            // Order document creation
+            var order = new Order({
+                type: OrderType[data.type],
+                description: data.description,
+                route: route._id,
+                status: Status[data.status],
+                truck: truck._id
+            });
+            yield order.save();
+            return res.status(200).send({ success: true, message: 'Order created succesfully.' });
+        }
+        catch (error) {
+            return res.status(400).send({ success: false, message: error.message });
+        }
+    });
+}
+export { AllOrders, CreateOrder };

--- a/dist/src/controllers/orders.js
+++ b/dist/src/controllers/orders.js
@@ -58,7 +58,7 @@ function CreateOrder(req, res) {
                 truck: truck._id
             });
             yield order.save();
-            return res.status(200).send({ success: true, message: 'Order created succesfully.' });
+            return res.status(200).send({ success: true, message: 'Order created succesfully.', orderId: order._id });
         }
         catch (error) {
             return res.status(400).send({ success: false, message: error.message });
@@ -78,8 +78,103 @@ function ReadOrder(req, res) {
                     }) });
             }
             const data = matchedData(req);
-            var order = yield Order.getOrder(data.orderId);
+            var order = yield Order.getExtendedOrder(data.orderId);
             return res.status(200).send({ success: true, order: order });
+        }
+        catch (error) {
+            return res.status(400).send({ success: false, message: error.message });
+        }
+    });
+}
+/**
+ * Updates an existing Order
+ */
+function NextStatus(req, res) {
+    return __awaiter(this, void 0, void 0, function* () {
+        try {
+            const result = validationResult(req);
+            if (!result.isEmpty()) { // Valid data for request
+                return res.status(400).send({ success: false, errors: result.array().map(function (err) {
+                        return err.msg; // Returns errors of data validation
+                    }) });
+            }
+            const data = matchedData(req);
+            // Look for the order
+            var order = yield Order.getOrder(data.orderId);
+            if (order.status == Status[Status.Completed]) {
+                // Order completed. There are no more changes
+                return res.status(200).send({ success: true, message: 'Order completed. No further status.' });
+            }
+            if (yield order.nextStatus()) {
+                return res.status(200).send({ success: true, message: 'Order status was successfully updated. Currently ' + Status[Status[order.status] + 1] });
+            }
+            else {
+                return res.status(200).send({ success: false, message: 'An error has occured on updating the status.' });
+            }
+        }
+        catch (error) {
+            return res.status(400).send({ success: false, message: error.message });
+        }
+    });
+}
+/**
+ * Updates an existing Order
+ */
+function UpdateOrder(req, res) {
+    return __awaiter(this, void 0, void 0, function* () {
+        try {
+            const result = validationResult(req);
+            if (!result.isEmpty()) { // Valid data for request
+                return res.status(400).send({ success: false, errors: result.array().map(function (err) {
+                        return err.msg; // Returns errors of data validation
+                    }) });
+            }
+            const data = matchedData(req);
+            // No changes requested
+            if (data.type == undefined && data.description == undefined &&
+                data.status == undefined && data.truck == undefined) {
+                if (data.route == undefined) {
+                    return res.status(200).send({ success: true, message: 'No changes requested' });
+                }
+                else if (data.route.pickup == undefined && data.route.dropoff == undefined)
+                    return res.status(200).send({ success: true, message: 'No changes requested' });
+            }
+            // Look for the order
+            var order = yield Order.getOrder(data.orderId);
+            if (order.status == Status[Status.Completed]) {
+                // Order completed. There are no more changes
+                return res.status(200).send({ success: true, message: 'Order completed. No changes allowed.' });
+            }
+            if (order.status == Status[Status.OnProgress]) {
+                // Order on progress. No changes allowed.
+                return res.status(200).send({ success: false, message: 'The order is in progress. It cannot be modified.' });
+            }
+            var routeId;
+            if (data.route != undefined) { // Change route ?
+                if (data.route.pickup != undefined || data.route.dropoff != undefined) { // New points for route
+                    var currentRoute = yield Route.getRouteById(order.route);
+                    // Get points for new route
+                    var pickup = data.route.pickup == undefined ? currentRoute.pointA.name : data.route.pickup;
+                    var dropoff = data.route.dropoff == undefined ? currentRoute.pointB.name : data.route.dropoff;
+                    // Verify updating points are valid.
+                    yield Point.getPoint(pickup);
+                    yield Point.getPoint(dropoff);
+                    // Verify existing new route.
+                    const newRoute = yield Route.getRoute(pickup, dropoff);
+                    routeId = newRoute._id;
+                }
+            }
+            var truckId;
+            if (data.truck != undefined) { // Change truck ?
+                // Verify valid truck
+                const newTruck = yield Truck.getTruck(data.truck);
+                truckId = newTruck._id;
+            }
+            const type = data.type == undefined ? undefined : OrderType[data.type];
+            const status = data.status == undefined ? undefined : Status[data.status];
+            // Update
+            yield order.updateOrder(type, data.description, routeId, status, truckId);
+            return res.status(200).send({ success: true, message: 'Order was successfully updated' });
         }
         catch (error) {
             return res.status(400).send({ success: false, message: error.message });
@@ -99,7 +194,7 @@ function DeleteOrder(req, res) {
                     }) });
             }
             const data = matchedData(req);
-            // If both points are valid, look for Order
+            // Look for the order
             var order = yield Order.getOrder(data.orderId);
             if (yield order.deleteOrder()) {
                 return res.status(200).send({ success: true, message: 'Order was successfully deleted' });
@@ -113,4 +208,4 @@ function DeleteOrder(req, res) {
         }
     });
 }
-export { AllOrders, CreateOrder, ReadOrder, DeleteOrder };
+export { AllOrders, CreateOrder, ReadOrder, UpdateOrder, DeleteOrder, NextStatus };

--- a/dist/src/controllers/orders.js
+++ b/dist/src/controllers/orders.js
@@ -1,0 +1,25 @@
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+import { Order } from '../../db/models/Order.js';
+/**
+ * Retrieves all orders available.
+ */
+function AllOrders(req, res) {
+    return __awaiter(this, void 0, void 0, function* () {
+        try {
+            var orders = yield Order.getAllOrders();
+            res.status(200).send(orders);
+        }
+        catch (error) {
+            res.status(500).send({ success: false, errors: error.message });
+        }
+    });
+}
+export { AllOrders };

--- a/dist/src/request/googleApi.js
+++ b/dist/src/request/googleApi.js
@@ -22,9 +22,15 @@ function GoogleGoordinatesRequest(placeId) {
     return __awaiter(this, void 0, void 0, function* () {
         yield delay(100);
         const url = `https://maps.googleapis.com/maps/api/geocode/json?place_id=${placeId}&key=${process.env.MAPS_GOOGLE_APIS_KEY}`;
-        console.log(url);
+        const options = {
+            method: 'GET',
+            headers: {
+                'Connection': 'keep-alive'
+            }
+        };
+        // console.log(url);
         try {
-            const response = yield fetch(url);
+            const response = yield fetch(url, options);
             const body = yield response.json();
             if (body.status == 'OK') {
                 return { lat: body.results[0].geometry.location.lat, lng: body.results[0].geometry.location.lng };
@@ -67,11 +73,14 @@ function GoogleDistanceRequest(from, to) {
             },
             "travelMode": "DRIVE"
         };
+        const apiKey = (process.env.MAPS_GOOGLE_APIS_KEY || '');
         const options = {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',
-                'X-Goog-Api-Key': process.env.MAPS_GOOGLE_APIS_KEY || '',
+                'Content-Length': JSON.stringify(data).length.toString(),
+                'Connection': 'keep-alive',
+                'X-Goog-Api-Key': apiKey,
                 'X-Goog-FieldMask': 'routes.distanceMeters'
             },
             body: JSON.stringify(data)

--- a/dist/src/routes/orders.js
+++ b/dist/src/routes/orders.js
@@ -1,18 +1,26 @@
 import express from 'express';
 import { body } from 'express-validator';
 import { OrderType, Status } from '../../db/models/Order.js';
-import { AllOrders, CreateOrder, ReadOrder, DeleteOrder } from '../controllers/orders.js';
+import { AllOrders, CreateOrder, ReadOrder, UpdateOrder, DeleteOrder, NextStatus } from '../controllers/orders.js';
 export const ordersRouter = express.Router();
 const orderDataValidatorSchema = [
-    body('type').isFloat({ min: 0, max: (Object.values(OrderType).length / 2 - 1) }).withMessage('Invalid type'),
+    body('type').optional().isFloat({ min: 0, max: (Object.values(OrderType).length / 2 - 1) }).withMessage('Invalid type'),
     body('description').trim().isLength({ min: 4 }).withMessage('Invalid description'),
     body('route.pickup').trim().isLength({ min: 4 }).withMessage('Invalid pickup'),
     body('route.dropoff').trim().isLength({ min: 4 }).withMessage('Invalid dropoff'),
-    body('status').isFloat({ min: 0, max: (Object.values(Status).length / 2 - 1) }).withMessage('Invalid status'),
+    body('status').optional().isFloat({ min: 0, max: (Object.values(Status).length / 2 - 1) }).withMessage('Invalid status'),
     body('truck').trim().isLength({ min: 10 }).withMessage('Invalid truck')
 ];
 const orderIdValidatorSchema = [
-    body('orderId').trim().isLength({ min: 10 }).withMessage('Invalid truck')
+    body('orderId').trim().isLength({ min: 10 }).withMessage('Invalid order id')
+];
+const orderUpdateValidatorSchema = [
+    body('type').optional().isFloat({ min: 0, max: (Object.values(OrderType).length / 2 - 1) }).withMessage('Invalid type'),
+    body('description').optional().trim().isLength({ min: 4 }).withMessage('Invalid description'),
+    body('route.pickup').optional().trim().isLength({ min: 4 }).withMessage('Invalid pickup'),
+    body('route.dropoff').optional().trim().isLength({ min: 4 }).withMessage('Invalid dropoff'),
+    body('status').optional().isFloat({ min: 0, max: (Object.values(Status).length / 2 - 1) }).withMessage('Invalid status'),
+    body('truck').optional().trim().isLength({ min: 10 }).withMessage('Invalid truck')
 ];
 /**
  * Retrieves all orders available
@@ -26,6 +34,14 @@ ordersRouter.post('/create', orderDataValidatorSchema, CreateOrder);
  * Reads an existing order
  */
 ordersRouter.get('/read', orderIdValidatorSchema, ReadOrder);
+/**
+ * Updates the status of an order
+ */
+ordersRouter.put('/nextStatus', orderIdValidatorSchema, NextStatus);
+/**
+ * Updates an existing order
+ */
+ordersRouter.put('/update', orderIdValidatorSchema.concat(orderUpdateValidatorSchema), UpdateOrder);
 /**
  * Deletes an existing order
  */

--- a/dist/src/routes/orders.js
+++ b/dist/src/routes/orders.js
@@ -1,15 +1,18 @@
 import express from 'express';
 import { body } from 'express-validator';
 import { OrderType, Status } from '../../db/models/Order.js';
-import { AllOrders, CreateOrder } from '../controllers/orders.js';
+import { AllOrders, CreateOrder, ReadOrder } from '../controllers/orders.js';
 export const ordersRouter = express.Router();
-const orderValidatorSchema = [
+const orderDataValidatorSchema = [
     body('type').isFloat({ min: 0, max: (Object.values(OrderType).length / 2 - 1) }).withMessage('Invalid type'),
     body('description').trim().isLength({ min: 4 }).withMessage('Invalid description'),
     body('route.pickup').trim().isLength({ min: 4 }).withMessage('Invalid pickup'),
     body('route.dropoff').trim().isLength({ min: 4 }).withMessage('Invalid dropoff'),
     body('status').isFloat({ min: 0, max: (Object.values(Status).length / 2 - 1) }).withMessage('Invalid status'),
     body('truck').trim().isLength({ min: 10 }).withMessage('Invalid truck')
+];
+const orderIdValidatorSchema = [
+    body('orderId').trim().isLength({ min: 10 }).withMessage('Invalid truck')
 ];
 /**
  * Retrieves all orders available
@@ -18,4 +21,8 @@ ordersRouter.get('/getAll', AllOrders);
 /**
  * Creates a new order
  */
-ordersRouter.post('/create', orderValidatorSchema, CreateOrder);
+ordersRouter.post('/create', orderDataValidatorSchema, CreateOrder);
+/**
+ * Reads an existing order
+ */
+ordersRouter.get('/read', orderIdValidatorSchema, ReadOrder);

--- a/dist/src/routes/orders.js
+++ b/dist/src/routes/orders.js
@@ -1,0 +1,7 @@
+import express from 'express';
+import { AllOrders } from '../controllers/orders.js';
+export const ordersRouter = express.Router();
+/**
+ * Retrieves all orders available
+ */
+ordersRouter.get('/getAll', AllOrders);

--- a/dist/src/routes/orders.js
+++ b/dist/src/routes/orders.js
@@ -1,7 +1,7 @@
 import express from 'express';
 import { body } from 'express-validator';
 import { OrderType, Status } from '../../db/models/Order.js';
-import { AllOrders, CreateOrder, ReadOrder } from '../controllers/orders.js';
+import { AllOrders, CreateOrder, ReadOrder, DeleteOrder } from '../controllers/orders.js';
 export const ordersRouter = express.Router();
 const orderDataValidatorSchema = [
     body('type').isFloat({ min: 0, max: (Object.values(OrderType).length / 2 - 1) }).withMessage('Invalid type'),
@@ -26,3 +26,7 @@ ordersRouter.post('/create', orderDataValidatorSchema, CreateOrder);
  * Reads an existing order
  */
 ordersRouter.get('/read', orderIdValidatorSchema, ReadOrder);
+/**
+ * Deletes an existing order
+ */
+ordersRouter.delete('/delete', orderIdValidatorSchema, DeleteOrder);

--- a/dist/src/routes/orders.js
+++ b/dist/src/routes/orders.js
@@ -1,7 +1,21 @@
 import express from 'express';
-import { AllOrders } from '../controllers/orders.js';
+import { body } from 'express-validator';
+import { OrderType, Status } from '../../db/models/Order.js';
+import { AllOrders, CreateOrder } from '../controllers/orders.js';
 export const ordersRouter = express.Router();
+const orderValidatorSchema = [
+    body('type').isFloat({ min: 0, max: (Object.values(OrderType).length / 2 - 1) }).withMessage('Invalid type'),
+    body('description').trim().isLength({ min: 4 }).withMessage('Invalid description'),
+    body('route.pickup').trim().isLength({ min: 4 }).withMessage('Invalid pickup'),
+    body('route.dropoff').trim().isLength({ min: 4 }).withMessage('Invalid dropoff'),
+    body('status').isFloat({ min: 0, max: (Object.values(Status).length / 2 - 1) }).withMessage('Invalid status'),
+    body('truck').trim().isLength({ min: 10 }).withMessage('Invalid truck')
+];
 /**
  * Retrieves all orders available
  */
 ordersRouter.get('/getAll', AllOrders);
+/**
+ * Creates a new order
+ */
+ordersRouter.post('/create', orderValidatorSchema, CreateOrder);

--- a/dist/src/routes/points.js
+++ b/dist/src/routes/points.js
@@ -4,4 +4,4 @@ export const pointsRouter = express.Router();
 /**
  * Retrieves all points available
  */
-pointsRouter.get('/get', AllPoints);
+pointsRouter.get('/getAll', AllPoints);

--- a/main.ts
+++ b/main.ts
@@ -8,6 +8,8 @@ import { authRouter } from './src/routes/auth.js'
 import { pointsRouter } from './src/routes/points.js'
 import { trucksRouter } from './src/routes/trucks.js'
 import { routesRouter } from './src/routes/routes.js'
+import { ordersRouter } from './src/routes/orders.js'
+
 import { notFound, validRequest } from './src/middleware/validation.js'
 
 setDBConnection().catch(err => {
@@ -34,6 +36,7 @@ app.use(validRequest);
 app.use('/points', pointsRouter);
 app.use('/trucks', trucksRouter);
 app.use('/routes', routesRouter);
+app.use('/orders', ordersRouter);
 
 // Server validation
 app.use(notFound);

--- a/src/controllers/orders.ts
+++ b/src/controllers/orders.ts
@@ -64,6 +64,26 @@ async function CreateOrder (req: Request, res: Response) {
     }
 }
 
+/**
+ * Retrieves an existing Order
+ */
+async function ReadOrder (req: Request, res: Response) {
+    try {
+        const result = validationResult(req);
+        if (!result.isEmpty()) { // Valid data for request
+            return res.status(400).send({ success: false, errors: result.array().map(function(err){
+                return err.msg // Returns errors of data validation
+            })});
+        }
+        const data = matchedData(req);
+        
+        var order = await Order.getOrder(data.orderId);
+
+        return res.status(200).send({ success: true, order : order });
+    } catch (error: any) {
+        return res.status(400).send({ success: false, message : error.message });
+    }
+}
 
 
-export { AllOrders, CreateOrder }
+export { AllOrders, CreateOrder, ReadOrder }

--- a/src/controllers/orders.ts
+++ b/src/controllers/orders.ts
@@ -1,0 +1,19 @@
+import { Request, Response } from 'express';
+
+import { Order } from '../../db/models/Order.js'
+
+/**
+ * Retrieves all orders available.
+ */
+async function AllOrders (req: Request, res: Response) {
+    try {
+        var orders = await Order.getAllOrders();
+
+        res.status(200).send(orders);
+    } catch (error: any) {
+        res.status(500).send({ success: false, errors : error.message });
+    }
+}
+
+
+export { AllOrders }

--- a/src/controllers/orders.ts
+++ b/src/controllers/orders.ts
@@ -65,7 +65,7 @@ async function CreateOrder (req: Request, res: Response) {
 }
 
 /**
- * Retrieves an existing Order
+ * Retrieves an existing order
  */
 async function ReadOrder (req: Request, res: Response) {
     try {
@@ -86,4 +86,31 @@ async function ReadOrder (req: Request, res: Response) {
 }
 
 
-export { AllOrders, CreateOrder, ReadOrder }
+/**
+ * Deletes an existing order
+ */
+async function DeleteOrder (req: Request, res: Response) {
+    try {
+        const result = validationResult(req);
+        if (!result.isEmpty()) { // Valid data for request
+            return res.status(400).send({ success: false, errors: result.array().map(function(err){
+                return err.msg // Returns errors of data validation
+            })});
+        }
+        const data = matchedData(req);
+
+        // If both points are valid, look for Order
+        var order = await Order.getOrder(data.orderId);
+
+        if(await order.deleteOrder()){
+            return res.status(200).send({ success: true, message : 'Order was successfully deleted' });
+        } else {
+            return res.status(200).send({ success: false, message : 'The order is in progress. It cannot be deleted.' });
+        }
+    } catch (error: any) {
+        return res.status(400).send({ success: false, message : error.message });
+    }
+}
+
+
+export { AllOrders, CreateOrder, ReadOrder, DeleteOrder }

--- a/src/controllers/orders.ts
+++ b/src/controllers/orders.ts
@@ -58,7 +58,7 @@ async function CreateOrder (req: Request, res: Response) {
         });
         await order.save();
 
-        return res.status(200).send({ success: true, message : 'Order created succesfully.' });
+        return res.status(200).send({ success: true, message : 'Order created succesfully.', orderId : order._id });
     } catch (error: any) {
         return res.status(400).send({ success: false, message : error.message });
     }
@@ -77,7 +77,7 @@ async function ReadOrder (req: Request, res: Response) {
         }
         const data = matchedData(req);
         
-        var order = await Order.getOrder(data.orderId);
+        var order = await Order.getExtendedOrder(data.orderId);
 
         return res.status(200).send({ success: true, order : order });
     } catch (error: any) {
@@ -85,6 +85,110 @@ async function ReadOrder (req: Request, res: Response) {
     }
 }
 
+
+/**
+ * Updates an existing Order
+ */
+async function NextStatus (req: Request, res: Response) {
+    try {
+        const result = validationResult(req);
+        if (!result.isEmpty()) { // Valid data for request
+            return res.status(400).send({ success: false, errors: result.array().map(function(err){
+                return err.msg // Returns errors of data validation
+            })});
+        }
+        const data = matchedData(req);
+
+        // Look for the order
+        var order = await Order.getOrder(data.orderId);
+
+        if(order.status == Status[Status.Completed]){
+            // Order completed. There are no more changes
+            return res.status(200).send({ success: true, message : 'Order completed. No further status.' });
+        }
+
+        if(await order.nextStatus()){
+            return res.status(200).send({ success: true, message : 'Order status was successfully updated. Currently ' + Status[Status[order.status] + 1] });
+        } else {
+            return res.status(200).send({ success: false, message : 'An error has occured on updating the status.' });
+        }
+    } catch (error: any) {
+        return res.status(400).send({ success: false, message : error.message });
+    }
+}
+
+/**
+ * Updates an existing Order
+ */
+async function UpdateOrder (req: Request, res: Response) {
+    try {
+        const result = validationResult(req);
+        if (!result.isEmpty()) { // Valid data for request
+            return res.status(400).send({ success: false, errors: result.array().map(function(err){
+                return err.msg // Returns errors of data validation
+            })});
+        }
+        const data = matchedData(req);
+        
+        // No changes requested
+        if(data.type == undefined && data.description == undefined &&
+            data.status == undefined && data.truck == undefined) { 
+            if(data.route == undefined){
+                return res.status(200).send({ success: true, message : 'No changes requested' });
+            } else if(data.route.pickup == undefined && data.route.dropoff == undefined)
+                return res.status(200).send({ success: true, message : 'No changes requested' });
+        }
+
+        // Look for the order
+        var order = await Order.getOrder(data.orderId);
+        
+        if(order.status == Status[Status.Completed]){
+            // Order completed. There are no more changes
+            return res.status(200).send({ success: true, message : 'Order completed. No changes allowed.' });
+        }
+        
+        if(order.status == Status[Status.OnProgress]){
+            // Order on progress. No changes allowed.
+            return res.status(200).send({ success: false, message : 'The order is in progress. It cannot be modified.' });
+        }
+
+        var routeId;
+        if(data.route != undefined){ // Change route ?
+            if(data.route.pickup != undefined || data.route.dropoff != undefined){ // New points for route
+                var currentRoute = await Route.getRouteById(order.route);
+                
+                // Get points for new route
+                var pickup = data.route.pickup == undefined ? currentRoute.pointA.name : data.route.pickup;
+                var dropoff = data.route.dropoff == undefined ? currentRoute.pointB.name : data.route.dropoff;
+                
+                // Verify updating points are valid.
+                await Point.getPoint(pickup);
+                await Point.getPoint(dropoff);
+
+                // Verify existing new route.
+                const newRoute = await Route.getRoute(pickup, dropoff);
+                routeId = newRoute._id;
+            }
+        }
+        
+        var truckId;
+        if(data.truck != undefined){ // Change truck ?
+            // Verify valid truck
+            const newTruck = await Truck.getTruck(data.truck);
+            truckId = newTruck._id;
+        }
+
+        const type = data.type == undefined ? undefined : OrderType[data.type];
+        const status = data.status == undefined ? undefined : Status[data.status];
+        
+        // Update
+        await order.updateOrder(type, data.description, routeId, status, truckId);
+
+        return res.status(200).send({ success: true, message : 'Order was successfully updated' });
+    } catch (error: any) {
+        return res.status(400).send({ success: false, message : error.message });
+    }
+}
 
 /**
  * Deletes an existing order
@@ -99,7 +203,7 @@ async function DeleteOrder (req: Request, res: Response) {
         }
         const data = matchedData(req);
 
-        // If both points are valid, look for Order
+        // Look for the order
         var order = await Order.getOrder(data.orderId);
 
         if(await order.deleteOrder()){
@@ -113,4 +217,4 @@ async function DeleteOrder (req: Request, res: Response) {
 }
 
 
-export { AllOrders, CreateOrder, ReadOrder, DeleteOrder }
+export { AllOrders, CreateOrder, ReadOrder, UpdateOrder, DeleteOrder, NextStatus }

--- a/src/controllers/orders.ts
+++ b/src/controllers/orders.ts
@@ -1,6 +1,10 @@
 import { Request, Response } from 'express';
+import { validationResult, matchedData } from 'express-validator';
 
-import { Order } from '../../db/models/Order.js'
+import { Order, OrderType, Status } from '../../db/models/Order.js'
+import { Route } from '../../db/models/Route.js'
+import { Truck } from '../../db/models/Truck.js'
+import { Point } from '../../db/models/Point.js'
 
 /**
  * Retrieves all orders available.
@@ -16,4 +20,50 @@ async function AllOrders (req: Request, res: Response) {
 }
 
 
-export { AllOrders }
+/**
+ * Creates a new valid order.
+ */
+async function CreateOrder (req: Request, res: Response) {
+    try {
+        const result = validationResult(req);
+        if (!result.isEmpty()) { // Valid data for request
+            return res.status(400).send({ success: false, errors: result.array().map(function(err){
+                return err.msg // Returns errors of data validation
+            })});
+        }
+        const data = matchedData(req);
+
+
+        if(data.route.pickup == data.route.dropoff){ // Departure and arrival must be different.
+            return res.status(400).send({ success: false, message : 'Invalid route payload' });
+        }
+
+        // First, verify that the starting and the ending Points are valid.
+        await Point.getPoint(data.route.pickup);
+        await Point.getPoint(data.route.dropoff);
+
+        // Verify valid route
+        const route = await Route.getRoute(data.route.pickup, data.route.dropoff);
+
+        // Verify valid truck
+        const truck = await Truck.getTruck(data.truck);
+
+        // Order document creation
+        var order = new Order({
+            type: OrderType[data.type],
+            description: data.description,
+            route : route._id,
+            status : Status[data.status],
+            truck : truck._id
+        });
+        await order.save();
+
+        return res.status(200).send({ success: true, message : 'Order created succesfully.' });
+    } catch (error: any) {
+        return res.status(400).send({ success: false, message : error.message });
+    }
+}
+
+
+
+export { AllOrders, CreateOrder }

--- a/src/request/googleApi.ts
+++ b/src/request/googleApi.ts
@@ -13,9 +13,16 @@ const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 async function GoogleGoordinatesRequest(placeId: string) {
     await delay(100);
     const url = `https://maps.googleapis.com/maps/api/geocode/json?place_id=${placeId}&key=${process.env.MAPS_GOOGLE_APIS_KEY}`
-    console.log(url);
+    
+    const options = {
+        method: 'GET',
+        headers: {
+            'Connection': 'keep-alive'
+        }
+    };
+    // console.log(url);
     try{
-        const response = await fetch(url);
+        const response = await fetch(url, options);
         const body = await response.json();
         if(body.status == 'OK'){
             return { lat: body.results[0].geometry.location.lat, lng : body.results[0].geometry.location.lng };
@@ -54,12 +61,14 @@ async function GoogleDistanceRequest(from, to) {
         },
         "travelMode": "DRIVE"
     };
-
+    const apiKey = (process.env.MAPS_GOOGLE_APIS_KEY || '')
     const options = {
         method: 'POST',
         headers: {
             'Content-Type': 'application/json',
-            'X-Goog-Api-Key': process.env.MAPS_GOOGLE_APIS_KEY || '',
+            'Content-Length': JSON.stringify(data).length.toString(),
+            'Connection': 'keep-alive',
+            'X-Goog-Api-Key': apiKey,
             'X-Goog-FieldMask': 'routes.distanceMeters'
         },
         body: JSON.stringify(data)

--- a/src/routes/orders.ts
+++ b/src/routes/orders.ts
@@ -1,0 +1,10 @@
+import express from 'express';
+
+import { AllOrders } from '../controllers/orders.js'
+
+export const ordersRouter = express.Router();
+
+/**
+ * Retrieves all orders available
+ */
+ordersRouter.get('/getAll', AllOrders);

--- a/src/routes/orders.ts
+++ b/src/routes/orders.ts
@@ -1,10 +1,33 @@
 import express from 'express';
+import { body } from 'express-validator';
 
-import { AllOrders } from '../controllers/orders.js'
+import { OrderType, Status } from '../../db/models/Order.js'
+
+import { AllOrders, CreateOrder } from '../controllers/orders.js'
 
 export const ordersRouter = express.Router();
+
+const orderValidatorSchema = [
+    body('type').isFloat({ min: 0, max: (Object.values(OrderType).length / 2 - 1) }).withMessage('Invalid type'),
+    body('description').trim().isLength({ min: 4 }).withMessage('Invalid description'),
+    body('route.pickup').trim().isLength({ min: 4 }).withMessage('Invalid pickup'),
+    body('route.dropoff').trim().isLength({ min: 4 }).withMessage('Invalid dropoff'),
+    body('status').isFloat({ min: 0, max: (Object.values(Status).length / 2 - 1) }).withMessage('Invalid status'),
+    body('truck').trim().isLength({ min: 10 }).withMessage('Invalid truck')
+];
 
 /**
  * Retrieves all orders available
  */
 ordersRouter.get('/getAll', AllOrders);
+
+/**
+ * Creates a new order
+ */
+ordersRouter.post('/create', orderValidatorSchema, CreateOrder);
+
+
+
+
+
+

--- a/src/routes/orders.ts
+++ b/src/routes/orders.ts
@@ -3,17 +3,21 @@ import { body } from 'express-validator';
 
 import { OrderType, Status } from '../../db/models/Order.js'
 
-import { AllOrders, CreateOrder } from '../controllers/orders.js'
+import { AllOrders, CreateOrder, ReadOrder } from '../controllers/orders.js'
 
 export const ordersRouter = express.Router();
 
-const orderValidatorSchema = [
+const orderDataValidatorSchema = [
     body('type').isFloat({ min: 0, max: (Object.values(OrderType).length / 2 - 1) }).withMessage('Invalid type'),
     body('description').trim().isLength({ min: 4 }).withMessage('Invalid description'),
     body('route.pickup').trim().isLength({ min: 4 }).withMessage('Invalid pickup'),
     body('route.dropoff').trim().isLength({ min: 4 }).withMessage('Invalid dropoff'),
     body('status').isFloat({ min: 0, max: (Object.values(Status).length / 2 - 1) }).withMessage('Invalid status'),
     body('truck').trim().isLength({ min: 10 }).withMessage('Invalid truck')
+];
+
+const orderIdValidatorSchema = [
+    body('orderId').trim().isLength({ min: 10 }).withMessage('Invalid truck')
 ];
 
 /**
@@ -24,8 +28,13 @@ ordersRouter.get('/getAll', AllOrders);
 /**
  * Creates a new order
  */
-ordersRouter.post('/create', orderValidatorSchema, CreateOrder);
+ordersRouter.post('/create', orderDataValidatorSchema, CreateOrder);
 
+
+/**
+ * Reads an existing order
+ */
+ordersRouter.get('/read', orderIdValidatorSchema, ReadOrder);
 
 
 

--- a/src/routes/orders.ts
+++ b/src/routes/orders.ts
@@ -3,21 +3,30 @@ import { body } from 'express-validator';
 
 import { OrderType, Status } from '../../db/models/Order.js'
 
-import { AllOrders, CreateOrder, ReadOrder, DeleteOrder } from '../controllers/orders.js'
+import { AllOrders, CreateOrder, ReadOrder, UpdateOrder, DeleteOrder, NextStatus } from '../controllers/orders.js'
 
 export const ordersRouter = express.Router();
 
 const orderDataValidatorSchema = [
-    body('type').isFloat({ min: 0, max: (Object.values(OrderType).length / 2 - 1) }).withMessage('Invalid type'),
+    body('type').optional().isFloat({ min: 0, max: (Object.values(OrderType).length / 2 - 1) }).withMessage('Invalid type'),
     body('description').trim().isLength({ min: 4 }).withMessage('Invalid description'),
     body('route.pickup').trim().isLength({ min: 4 }).withMessage('Invalid pickup'),
     body('route.dropoff').trim().isLength({ min: 4 }).withMessage('Invalid dropoff'),
-    body('status').isFloat({ min: 0, max: (Object.values(Status).length / 2 - 1) }).withMessage('Invalid status'),
+    body('status').optional().isFloat({ min: 0, max: (Object.values(Status).length / 2 - 1) }).withMessage('Invalid status'),
     body('truck').trim().isLength({ min: 10 }).withMessage('Invalid truck')
 ];
 
 const orderIdValidatorSchema = [
-    body('orderId').trim().isLength({ min: 10 }).withMessage('Invalid truck')
+    body('orderId').trim().isLength({ min: 10 }).withMessage('Invalid order id')
+];
+
+const orderUpdateValidatorSchema = [
+    body('type').optional().isFloat({ min: 0, max: (Object.values(OrderType).length / 2 - 1) }).withMessage('Invalid type'),
+    body('description').optional().trim().isLength({ min: 4 }).withMessage('Invalid description'),
+    body('route.pickup').optional().trim().isLength({ min: 4 }).withMessage('Invalid pickup'),
+    body('route.dropoff').optional().trim().isLength({ min: 4 }).withMessage('Invalid dropoff'),
+    body('status').optional().isFloat({ min: 0, max: (Object.values(Status).length / 2 - 1) }).withMessage('Invalid status'),
+    body('truck').optional().trim().isLength({ min: 10 }).withMessage('Invalid truck')
 ];
 
 /**
@@ -35,6 +44,16 @@ ordersRouter.post('/create', orderDataValidatorSchema, CreateOrder);
  * Reads an existing order
  */
 ordersRouter.get('/read', orderIdValidatorSchema, ReadOrder);
+
+/**
+ * Updates the status of an order
+ */
+ordersRouter.put('/nextStatus', orderIdValidatorSchema, NextStatus);
+
+/**
+ * Updates an existing order
+ */
+ordersRouter.put('/update', orderIdValidatorSchema.concat(orderUpdateValidatorSchema), UpdateOrder);
 
 /**
  * Deletes an existing order

--- a/src/routes/orders.ts
+++ b/src/routes/orders.ts
@@ -3,7 +3,7 @@ import { body } from 'express-validator';
 
 import { OrderType, Status } from '../../db/models/Order.js'
 
-import { AllOrders, CreateOrder, ReadOrder } from '../controllers/orders.js'
+import { AllOrders, CreateOrder, ReadOrder, DeleteOrder } from '../controllers/orders.js'
 
 export const ordersRouter = express.Router();
 
@@ -25,16 +25,21 @@ const orderIdValidatorSchema = [
  */
 ordersRouter.get('/getAll', AllOrders);
 
+
 /**
  * Creates a new order
  */
 ordersRouter.post('/create', orderDataValidatorSchema, CreateOrder);
 
-
 /**
  * Reads an existing order
  */
 ordersRouter.get('/read', orderIdValidatorSchema, ReadOrder);
+
+/**
+ * Deletes an existing order
+ */
+ordersRouter.delete('/delete', orderIdValidatorSchema, DeleteOrder);
 
 
 

--- a/src/routes/points.ts
+++ b/src/routes/points.ts
@@ -7,4 +7,4 @@ export const pointsRouter = express.Router();
 /**
  * Retrieves all points available
  */
-pointsRouter.get('/get', AllPoints);
+pointsRouter.get('/getAll', AllPoints);


### PR DESCRIPTION
Added a CRUD module for routes.
6 new endpoints were added to the API.

- `GET /orders/getAll`: retrieves all the orders.
- `POST /orders/create`: creates a new order. `description`, `route` and `truck` must be provided. `type` and `status` data are optional. If created, `orderId` is returned.
- `GET /orders/read`: returns the data of an existing order. `orderId` value is required.
- `PUT /orders/nextStatus`: updates the status of an order to the next status of the enum. `orderId` value is required.
- `PUT /orders/update`: updates the data of an existing order. `orderId` value is required. `description`, `route`, `truck`, `type` and `status` are optional. But if specified, updating is performed. 
- `DELETE /orders/delete`: deletes an existing order using the `orderId`.

The value fields format for this module are:
`type`: number in range 0 to 2. Maped to the `OrderType enum` which values are _Normal_, _Urgent_, _Fragile_. As the string values are stored in DB, number values are used on endpoints consumption.
`description`: string, length at least 4.
`route`: object, with two keys: `pickup` and `dropoff`. Both values must be the names of valid Points.
`status`: number in range 0 to 3. Maped to the `Status enum` which values are stored in DB and are _Created_, _Scheduled_, _OnProgress_, _Completed_. As the string values are stored in DB, number values are used on endpoints consumption.
`truck`: string, it must be the `oid` of an existing truck.

Note that an order cannot be updated if order status is _OnProgress_ or _Completed_, and it cannot be deleted if order status is _OnProgress_,